### PR TITLE
Fix the problem of getting wrong TINKER_ID from meta-data

### DIFF
--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareTinkerInternals.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareTinkerInternals.java
@@ -177,7 +177,8 @@ public class ShareTinkerInternals {
 
             Object object = appInfo.metaData.get(ShareConstants.TINKER_ID);
             if (object != null) {
-                tinkerID = String.valueOf(object);
+                String tinkerIdValue = String.valueOf(object);
+                tinkerID = tinkerIdValue.replace(ShareConstants.TINKER_ID + "_", "");
             } else {
                 tinkerID = null;
             }

--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerManifestTask.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerManifestTask.groovy
@@ -45,6 +45,8 @@ public class TinkerManifestTask extends DefaultTask {
         }
         project.logger.error("tinker add ${tinkerValue} to your AndroidManifest.xml ${manifestPath}")
 
+        tinkerValue = "${TINKER_ID}_${tinkerValue}"
+
         def ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
 
         def xml = new XmlParser().parse(new InputStreamReader(new FileInputStream(manifestPath), "utf-8"))

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/info/PatchInfoGen.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/info/PatchInfoGen.java
@@ -42,8 +42,9 @@ public class PatchInfoGen {
     private void addTinkerID() throws IOException, ParseException {
         if (!config.mPackageFields.containsKey(TypedValue.TINKER_ID)) {
             AndroidParser oldAndroidManifest = AndroidParser.getAndroidManifest(config.mOldApkFile);
-            String tinkerID = oldAndroidManifest.metaDatas.get(TypedValue.TINKER_ID);
+            String tinkerIdValue = oldAndroidManifest.metaDatas.get(TypedValue.TINKER_ID);
 
+            String tinkerID = tinkerIdValue.replace(TypedValue.TINKER_ID + "_", "");
             if (tinkerID == null) {
                 throw new TinkerPatchException("can't find TINKER_ID from the old apk manifest file, it must be set!");
             }
@@ -52,8 +53,9 @@ public class PatchInfoGen {
 
         if (!config.mPackageFields.containsKey(TypedValue.NEW_TINKER_ID)) {
             AndroidParser newAndroidManifest = AndroidParser.getAndroidManifest(config.mNewApkFile);
-            String tinkerID = newAndroidManifest.metaDatas.get(TypedValue.TINKER_ID);
+            String tinkerIdValue = newAndroidManifest.metaDatas.get(TypedValue.TINKER_ID);
 
+            String tinkerID = tinkerIdValue.replace(TypedValue.TINKER_ID + "_", "");
             if (tinkerID == null) {
                 throw new TinkerPatchException("can't find TINKER_ID from the new apk manifest file, it must be set!");
             }


### PR DESCRIPTION
fix the problem of getting wrong TINKER_ID from meta-data if the TINKER_ID only contain numeric character, such as 0101, 201611111001 etc