### PR TITLE
[bugfix] reset tinkerId to resolve when build all flavor patch one time has same tinkerId

### DIFF
--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/info/PatchInfoGen.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/info/PatchInfoGen.java
@@ -71,5 +71,8 @@ public class PatchInfoGen {
         String comment = "base package config field";
         newProperties.store(new FileOutputStream(packageInfoFile, false), comment);
 
+        // reset tinkerId to resolve when build all flavor patch one time has same tinkerId
+        config.mPackageFields.remove(TypedValue.TINKER_ID);
+        config.mPackageFields.remove(TypedValue.NEW_TINKER_ID);
     }
 }


### PR DESCRIPTION
一次性打所有渠道包，tinker无法正确获取具体渠道基线版本的tinkerId，只能一次打一个渠道包的补丁。
多次打渠道包的时候，因为没有清除缓存的tinkerId，就不会重新去拿其他渠道的基线apk的tinkerId，所以才会导致其他渠道还是第一次拿到的tinkerId。此次提交修复了这个问题。