### PR TITLE
let "OLD_APK" property can set as path or file name.

### DIFF
--- a/tinker-sample-android/app/build.gradle
+++ b/tinker-sample-android/app/build.gradle
@@ -159,8 +159,9 @@ ext {
     //old apk file to build patch apk
     tinkerOldApkPath = "${bakPath}/app-debug-1018-17-32-47.apk"
     if (project.hasProperty("OLD_APK")) {
-        File file = new File(OLD_APK)
-        tinkerOldApkPath = file.isAbsolute() ? OLD_APK : "${bakPath}/" + OLD_APK
+        String oldApk = OLD_APK
+        tinkerOldApkPath = (oldApk.indexOf('\\') > 0 || oldApk.indexOf('/') > 0) ? OLD_APK :
+                "${bakPath}/" + OLD_APK
     }
     pathPrefix = getPathPrefix(tinkerOldApkPath)
     //proguard mapping file to build patch apk

--- a/tinker-sample-android/app/build.gradle
+++ b/tinker-sample-android/app/build.gradle
@@ -158,18 +158,31 @@ ext {
     //for normal build
     //old apk file to build patch apk
     tinkerOldApkPath = "${bakPath}/app-debug-1018-17-32-47.apk"
+    if (project.hasProperty("OLD_APK")) {
+        File file = new File(OLD_APK)
+        tinkerOldApkPath = file.isAbsolute() ? OLD_APK : "${bakPath}/" + OLD_APK
+    }
+    pathPrefix = getPathPrefix(tinkerOldApkPath)
     //proguard mapping file to build patch apk
-    tinkerApplyMappingPath = "${bakPath}/app-debug-1018-17-32-47-mapping.txt"
+    tinkerApplyMappingPath = "${pathPrefix}-mapping.txt"
     //resource R.txt to build patch apk, must input if there is resource changed
-    tinkerApplyResourcePath = "${bakPath}/app-debug-1018-17-32-47-R.txt"
+    tinkerApplyResourcePath = "${pathPrefix}-R.txt"
 
     //only use for build all flavor, if not, just ignore this field
     tinkerBuildFlavorDirectory = "${bakPath}/app-1018-17-32-47"
 }
 
+static def getPathPrefix(String path) {
+    int dotIndex = path != null ? path.lastIndexOf('.') : -1
+    if (dotIndex >= 0 && dotIndex < path.length() - 1) {
+        return path.substring(0, dotIndex)
+    }
+    return path
+}
+
 
 def getOldApkPath() {
-    return hasProperty("OLD_APK") ? OLD_APK : ext.tinkerOldApkPath
+    return ext.tinkerOldApkPath
 }
 
 def getApplyMappingPath() {


### PR DESCRIPTION
出补丁包时让改的方便点，写一下文件名即可，基准包路径绝对路径相对路径都可以，同时兼容原来的处理方式。