### PR TITLE
Fix issue-866, 修复对较大功能使用热修复时，偶现的ClassCastException: AbsSavedState$1 -> XXX$SavedState

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
@@ -168,6 +168,11 @@ class TinkerPatchPlugin implements Plugin<Project> {
                 applyResourceTask.mustRunAfter manifestTask
 
                 variantOutput.processResources.dependsOn applyResourceTask
+                // Fix issue-866.
+                // We found some case that applyResourceTask run after mergeResourcesTask, it caused 'applyResourceMapping' config not work.
+                // The task need merged resources to calculate ids.xml, it must depends on merge resources task.
+                def mergeResourcesTask = project.tasks.findByName("merge${variantName.capitalize()}Resources")
+                applyResourceTask dependsOn mergeResourcesTask
 
                 if (manifestTask.manifestPath == null || applyResourceTask.resDir == null) {
                     throw new RuntimeException("manifestTask.manifestPath or applyResourceTask.resDir is null.")


### PR DESCRIPTION
近期我们对较大的功能使用tinker来做热更新发布，线上出现较多的此类异常：
`java.lang.ClassCastException:android.view.AbsSavedState$1 cannot be cast to android.widget.HorizontalScrollView$SavedState
android.widget.HorizontalScrollView.onRestoreInstanceState(HorizontalScrollView.java:1705)
android.view.View.dispatchRestoreInstanceState(View.java:14929)
android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3252)
android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3258)
android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3258)
android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:3258)
android.view.View.restoreHierarchyState(View.java:14907)
android.support.v4.app.Fragment.restoreViewState(Fragment.java:396)`

      分析后发现原因是由于新合成的APK中资源ID变化非常大，导致用户安装热更新后，之前saveInstance存储的view状态在恢复时出现ID错乱导致，详见View#onRestoreInstanceState方法；
      由于我们项目中已经配置了applyResourceMapping，因此分析没有生效的原因，本机不能复现，但是linux的构建机稳定复现，在applyResourceTask结束之后断点，发现生成的ids.xml和public.xml都是空，进一步分析，发现在applyResourceTask执行时，由于mergeResourcesTask还没有完成，导致applyResourceTask不能正常生成ids.xml和public.xml，翻阅android gradle plugin源码发现mergeResourcesTask并没有强制一定在processManifest之前，更不能保证在applyResourceTask之前；
      解决方法：增加applyResourceTask dependsOn mergeResourcesTask，测试通过；