### PR TITLE
Fix Android 9.0 Inlined method resolution crossed dex file boundary And Andriod Q don't generate odex file.

### DIFF
--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/AndroidNClassLoader.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/AndroidNClassLoader.java
@@ -165,7 +165,9 @@ class AndroidNClassLoader extends PathClassLoader {
         } else if (name != null && name.startsWith("com.tencent.tinker.loader.")
                 && !name.equals(SystemClassLoaderAdder.CHECK_DEX_CLASS)) {
             return originClassLoader.loadClass(name);
-        } else if (name != null && name.startsWith("org.apache.http.")) {
+        } else if (name != null &&  (name.startsWith("org.apache.commons.codec.") 
+                                     || name.startsWith("org.apache.commons.logging.")
+                                     || name.startsWith("org.apache.http."))) {
             // Here's the whole story:
             //   Some app use apache wrapper library to access Apache utilities. Classes in apache wrapper
             //   library may be conflict with those preloaded in BootClassLoader.

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/SharePatchFileUtil.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/SharePatchFileUtil.java
@@ -177,7 +177,8 @@ public class SharePatchFileUtil {
      * @return
      */
     public static final boolean shouldAcceptEvenIfIllegal(File file) {
-        return ("vivo".equalsIgnoreCase(Build.MANUFACTURER) || "oppo".equalsIgnoreCase(Build.MANUFACTURER))
+        return ("vivo".equalsIgnoreCase(Build.MANUFACTURER) || "oppo".equalsIgnoreCase(Build.MANUFACTURER)
+                || (Build.VERSION.SDK_INT > 28) || (Build.VERSION.SDK_INT == 28 && Build.VERSION.PREVIEW_SDK_INT > 0))
                 && (!file.exists() || file.length() == 0);
     }
 


### PR DESCRIPTION
Maybe classes in package org.apache.commons.codec or org.apache.commons.logging will be inline too.

I found this exception happened on OnePlus H2OS 9.0.1.

See the Artical:
 - [通告 | Android P新增检测项 应用热修复受重大影响](https://mp.weixin.qq.com/s?__biz=MzI0MjgxMjU0Mg==&mid=2247488357&idx=1&sn=d393bd028dfbf87998b80e06ca24bc94&scene=21#wechat_redirect)
 - [entrypoint_utils-inl.h#94](https://android.googlesource.com/platform/art/+/android-9.0.0_r16/runtime/entrypoints/entrypoint_utils-inl.h#94)

![apache-legacy](https://si.geilicdn.com/img-47d800000169c8341a160a217216-unadjust_418_205.png)

![inline](https://si.geilicdn.com/img-6acf00000169c8353c170a217205-unadjust_1781_378.png)