### PR TITLE
fix the missing `break`

### DIFF
--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/ExcludedClassModifiedChecker.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/ExcludedClassModifiedChecker.java
@@ -193,6 +193,7 @@ public final class ExcludedClassModifiedChecker {
                     final String msg = "loader classes are found in old secondary dex. Found classes: " + Utils.collectionToString(oldClassesDescToCheck);
                     if (config.mAllowLoaderInAnyDex) {
                         Logger.d(msg);
+                        break;
                     } else {
                         throw new TinkerPatchException(msg);
                     }
@@ -201,6 +202,7 @@ public final class ExcludedClassModifiedChecker {
                     final String msg = "loader classes are found in new secondary dex. Found classes: " + Utils.collectionToString(newClassesDescToCheck);
                     if (config.mAllowLoaderInAnyDex) {
                         Logger.d(msg);
+                        break;
                     } else {
                         throw new TinkerPatchException(msg);
                     }


### PR DESCRIPTION
Sorry. I missed the break statement in last pull requests which may cause NullPointerException in the next case.

This pull request fixes it.