### PR TITLE
fix bug of unzip apk

### DIFF
--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/FileOperation.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/FileOperation.java
@@ -186,10 +186,17 @@ public class FileOperation {
 
                 File file = new File(filePath + File.separator + entry.getName());
 
+                //fix bug
                 File parentFile = file.getParentFile();
-                if (parentFile != null && (!parentFile.exists())) {
+                if (!parentFile.isDirectory()) {
+                    if (parentFile.exists()) {
+                        parentFile.delete();
+                    }
                     parentFile.mkdirs();
                 }
+//                if (parentFile != null && (!parentFile.exists())) {
+//                    parentFile.mkdirs();
+//                }
                 FileOutputStream fos = null;
                 BufferedOutputStream bos = null;
                 try {


### PR DESCRIPTION
zip路径不规范时，会有解压apk时部分目录被解成文件的问题，导致无法制作补丁。