### PR TITLE
* Android Gradle Plugin 3.4.0+ R8 support

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerMultidexConfigTask.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerMultidexConfigTask.groovy
@@ -48,6 +48,7 @@ public class TinkerMultidexConfigTask extends DefaultTask {
 
 
     def applicationVariant
+    def multiDexKeepProguard
 
     public TinkerMultidexConfigTask() {
         group = 'tinker'
@@ -101,30 +102,6 @@ public class TinkerMultidexConfigTask extends DefaultTask {
             fr.close()
         }
 
-        File multiDexKeepProguard = null
-        try {
-            multiDexKeepProguard = applicationVariant.getVariantData().getScope().getManifestKeepListProguardFile()
-        } catch (Throwable ignore) {
-            try {
-                def buildableArtifact = applicationVariant.getVariantData().getScope().getArtifacts().getFinalArtifactFiles(
-                        Class.forName("com.android.build.gradle.internal.scope.InternalArtifactType")
-                                .getDeclaredField("LEGACY_MULTIDEX_AAPT_DERIVED_PROGUARD_RULES")
-                                .get(null)
-                )
-
-                //noinspection GroovyUncheckedAssignmentOfMemberOfRawType,UnnecessaryQualifiedReference
-                multiDexKeepProguard = com.google.common.collect.Iterators.getOnlyElement(buildableArtifact.iterator())
-            } catch (Throwable e) {
-
-            }
-            if (multiDexKeepProguard == null) {
-                try {
-                    multiDexKeepProguard = applicationVariant.getVariantData().getScope().getManifestKeepListFile()
-                } catch (Throwable e) {
-                    project.logger.error("can't find getManifestKeepListFile method, exception:${e}")
-                }
-            }
-        }
         if (multiDexKeepProguard == null) {
             project.logger.error("auto add multidex keep pattern fail, you can only copy ${file} to your own multiDex keep proguard file yourself.")
             return


### PR DESCRIPTION
疑似AGP的bug，此处tinker进行兼容。Android Gradle Plugin 3.4.0+ 开启R8时，由于未将计算得到的manifest multidex proguard file添加到R8Transform中导致很多类不在主dex中，在dalvik上启动crash，在art上patch校验dex是否加载成功失败，