### PR TITLE
* compat for aaptOptions modify in agp 3.5.0

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
@@ -376,8 +376,8 @@ class TinkerPatchPlugin implements Plugin<Project> {
     }
 
     Task getR8Task(Project project, String variantName) {
-        String d8TaskName = "transformClassesAndResourcesWithR8For${variantName}"
-        return project.tasks.findByName(d8TaskName)
+        String r8TaskName = "transformClassesAndResourcesWithR8For${variantName}"
+        return project.tasks.findByName(r8TaskName)
     }
 
     @NotNull


### PR DESCRIPTION
processAndroidResourcesTask.getAaptOptions() 与 processAndroidResourcesTask.setAaptOptions()被移除

processAndroidResourcesTask.aaptOptions由**com.android.build.gradle.internal.dsl.AaptOptions**变为**com.android.builder.internal.aapt.AaptOptions**