### PR TITLE
针对包含动态插件技术和特殊使用场景的App，提交两个Feature

### DIFF
--- a/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/reporter/DefaultLoadReporter.java
+++ b/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/reporter/DefaultLoadReporter.java
@@ -87,8 +87,10 @@ public class DefaultLoadReporter implements LoadReporter {
             return;
         }
 
-        //check main process
-        if (!Tinker.with(context).isMainProcess()) {
+        // check if current process installed a new version patch
+        Tinker tinker = Tinker.with(context);
+        TinkerLoadResult tinkerLoadResult = tinker.getTinkerLoadResultIfPresent();
+        if (!tinkerLoadResult.runNewVersion) {
             return;
         }
 
@@ -310,18 +312,15 @@ public class DefaultLoadReporter implements LoadReporter {
      */
     public void checkAndCleanPatch() {
         Tinker tinker = Tinker.with(context);
-        //only main process can load a new patch
-        if (tinker.isMainProcess()) {
-            TinkerLoadResult tinkerLoadResult = tinker.getTinkerLoadResultIfPresent();
-            //if versionChange and the old patch version is not ""
-            if (tinkerLoadResult.versionChanged) {
-                SharePatchInfo sharePatchInfo = tinkerLoadResult.patchInfo;
-                if (sharePatchInfo != null && !ShareTinkerInternals.isNullOrNil(sharePatchInfo.oldVersion)) {
-                    TinkerLog.w(TAG, "checkAndCleanPatch, oldVersion %s is not null, try kill all other process",
+        TinkerLoadResult tinkerLoadResult = tinker.getTinkerLoadResultIfPresent();
+        // only main process with correct environment can load a new patch
+        if (tinkerLoadResult.runNewVersion) {
+            SharePatchInfo sharePatchInfo = tinkerLoadResult.patchInfo;
+            if (sharePatchInfo != null && !ShareTinkerInternals.isNullOrNil(sharePatchInfo.oldVersion)) {
+                TinkerLog.w(TAG, "checkAndCleanPatch, oldVersion %s is not null, try kill all other process",
                         sharePatchInfo.oldVersion);
 
-                    ShareTinkerInternals.killAllOtherProcess(context);
-                }
+                ShareTinkerInternals.killAllOtherProcess(context);
             }
         }
         tinker.cleanPatch();

--- a/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/tinker/TinkerApplicationHelper.java
+++ b/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/tinker/TinkerApplicationHelper.java
@@ -221,13 +221,9 @@ public class TinkerApplicationHelper {
         }
         final String oldVersion = ShareIntentUtil.getStringExtra(tinkerResultIntent, ShareIntentUtil.INTENT_PATCH_OLD_VERSION);
         final String newVersion = ShareIntentUtil.getStringExtra(tinkerResultIntent, ShareIntentUtil.INTENT_PATCH_NEW_VERSION);
-        final boolean isMainProcess = ShareTinkerInternals.isInMainProcess(applicationLike.getApplication());
+        final boolean runNewVersion = ShareIntentUtil.getBooleanExtra(tinkerResultIntent, ShareIntentUtil.INTENT_PATCH_RUN_NEW_VERSION, false);
         if (oldVersion != null && newVersion != null) {
-            if (isMainProcess) {
-                return newVersion;
-            } else {
-                return oldVersion;
-            }
+            return runNewVersion ? newVersion : oldVersion;
         }
         return null;
     }

--- a/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/tinker/TinkerLoadResult.java
+++ b/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/tinker/TinkerLoadResult.java
@@ -43,6 +43,8 @@ public class TinkerLoadResult {
     //@Nullable
     public String         oatDir;
 
+    public boolean runNewVersion;
+
     public boolean versionChanged;
 
     public boolean useInterpretMode;
@@ -81,10 +83,10 @@ public class TinkerLoadResult {
         oatDir = ShareIntentUtil.getStringExtra(intentResult, ShareIntentUtil.INTENT_PATCH_OAT_DIR);
         useInterpretMode = ShareConstants.INTERPRET_DEX_OPTIMIZE_PATH.equals(oatDir);
 
-        final boolean isMainProcess = tinker.isMainProcess();
+        runNewVersion = ShareIntentUtil.getBooleanExtra(intentResult, ShareIntentUtil.INTENT_PATCH_RUN_NEW_VERSION, false);
 
-        TinkerLog.i(TAG, "parseTinkerResult loadCode:%d, process name:%s, main process:%b, systemOTA:%b, fingerPrint:%s, oatDir:%s, useInterpretMode:%b",
-            loadCode, ShareTinkerInternals.getProcessName(context), isMainProcess, systemOTA, Build.FINGERPRINT, oatDir, useInterpretMode);
+        TinkerLog.i(TAG, "parseTinkerResult loadCode:%d, process name:%s, main process:%b, runNewVersion:%b, systemOTA:%b, fingerPrint:%s, oatDir:%s, useInterpretMode:%b",
+            loadCode, ShareTinkerInternals.getProcessName(context), tinker.isMainProcess(), runNewVersion, systemOTA, Build.FINGERPRINT, oatDir, useInterpretMode);
 
         //@Nullable
         final String oldVersion = ShareIntentUtil.getStringExtra(intentResult, ShareIntentUtil.INTENT_PATCH_OLD_VERSION);
@@ -95,11 +97,7 @@ public class TinkerLoadResult {
         final File patchInfoFile = tinker.getPatchInfoFile();
 
         if (oldVersion != null && newVersion != null) {
-            if (isMainProcess) {
-                currentVersion = newVersion;
-            } else {
-                currentVersion = oldVersion;
-            }
+            currentVersion = runNewVersion ? newVersion : oldVersion;
 
             TinkerLog.i(TAG, "parseTinkerResult oldVersion:%s, newVersion:%s, current:%s", oldVersion, newVersion,
                 currentVersion);
@@ -331,7 +329,7 @@ public class TinkerLoadResult {
                 if (useInterpretMode) {
                     tinker.getLoadReporter().onLoadInterpret(ShareConstants.TYPE_INTERPRET_OK, null);
                 }
-                if (isMainProcess && versionChanged) {
+                if (runNewVersion) {
                     //change the old version to new
                     tinker.getLoadReporter().onLoadPatchVersionChanged(oldVersion, newVersion, patchDirectory, patchVersionDirectory.getName());
                 }

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/AbstractTinkerLoader.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/AbstractTinkerLoader.java
@@ -25,5 +25,19 @@ import com.tencent.tinker.loader.app.TinkerApplication;
  * Created by zhangshaowen on 16/4/30.
  */
 public abstract class AbstractTinkerLoader {
+
     abstract public Intent tryLoad(TinkerApplication app);
+
+    /**
+     * Should we install a new patch?
+     *
+     * Usually we load the fresh one as soon as the main process
+     * starts, and this will get others killed. However, there are
+     * some scenarios where a not-main process is too important to
+     * be killed, such as a music player process.
+     *
+     * If those process exists (or for other reasons), we return a
+     * FALSE to avoid main process loading the new patch.
+     */
+    abstract public boolean greetNewPatch();
 }

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/AbstractTinkerLoader.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/AbstractTinkerLoader.java
@@ -39,5 +39,5 @@ public abstract class AbstractTinkerLoader {
      * If those process exists (or for other reasons), we return a
      * FALSE to avoid main process loading the new patch.
      */
-    abstract public boolean greetNewPatch();
+    abstract public boolean greetNewPatch(TinkerApplication app);
 }

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerLoader.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerLoader.java
@@ -60,7 +60,7 @@ public class TinkerLoader extends AbstractTinkerLoader {
     }
 
     @Override
-    public boolean greetNewPatch() {
+    public boolean greetNewPatch(TinkerApplication app) {
         return true;
     }
 
@@ -163,7 +163,7 @@ public class TinkerLoader extends AbstractTinkerLoader {
         oatDex = ShareTinkerInternals.getCurrentOatMode(app, oatDex);
         resultIntent.putExtra(ShareIntentUtil.INTENT_PATCH_OAT_DIR, oatDex);
 
-        final boolean runNewVersion = mainProcess && versionChanged && greetNewPatch();
+        final boolean runNewVersion = mainProcess && versionChanged && greetNewPatch(app);
         final boolean runNewOatMode = mainProcess && oatModeChanged;
         resultIntent.putExtra(ShareIntentUtil.INTENT_PATCH_RUN_NEW_VERSION, runNewVersion);
 

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerResourcesKey.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerResourcesKey.java
@@ -16,6 +16,17 @@
 
 package com.tencent.tinker.loader;
 
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static com.tencent.tinker.loader.shareutil.ShareReflectUtil.findField;
+
 /**
  * Created by zhangshaowen on 17/1/12.
  *
@@ -25,20 +36,414 @@ package com.tencent.tinker.loader;
  */
 public class TinkerResourcesKey {
 
-    private static final class V24 {
+    private static final String TAG = "Tinker.ResourcesKey";
 
+    public static String lookOverUnadaptedInfo() {
+        try {
+            checkClassCorrect();
+        } catch (Throwable ignore) {
+            StringBuilder info = new StringBuilder("ClassInfo { ");
+            try {
+                Class ResourcesKeyClazz = BaseKey.ResourcesKeyClazz;
+                info.append(ResourcesKeyClazz.getName()).append(", ");
+                Constructor[] constructors = ResourcesKeyClazz.getDeclaredConstructors();
+                for (Constructor c : constructors) {
+                    if (c == null) {
+                        continue;
+                    }
+                    c.setAccessible(true);
+                    Class[] args = c.getParameterTypes();
+                    if (args != null && args.length > 0) {
+                        info.append(Arrays.deepToString(args)).append(", ");
+                    }
+                }
+            } catch (Throwable e) {
+                info.append("err=" + e.getMessage()).append(" ");
+            }
+            info.append("}");
+            return info.toString();
+        }
+        return null;
+    }
+
+    static void checkClassCorrect() throws Throwable {
+        BaseKey keyWrap = createLyingKey();
+        keyWrap.getConstructor();
+    }
+
+    static String getResDir(Object resourcesKey) throws Exception {
+        return (String) BaseKey.mResDirField.get(resourcesKey);
+    }
+
+    static Object newKey(Object oldKey, String newResourcePath) throws Exception {
+        BaseKey keyWrap = createLyingKey();
+        if (keyWrap != null) {
+            return keyWrap.getNewKey(oldKey, newResourcePath);
+        }
+        throw new IllegalAccessException("can not create new ResourcesKey object");
+    }
+
+    private static BaseKey createLyingKey() {
+        final int sdk = Build.VERSION.SDK_INT;
+        BaseKey key = null;
+        if (sdk >= 24) {
+            key =  new V24();
+        } else if (sdk >= 23) {
+            key =  new V23();
+        } else if (sdk >= 19) {
+            key =  new V19();
+        } else if (sdk >= 17) {
+            key =  new V17();
+        } else if (sdk >= 16) {
+            key =  new V16();
+        }
+        try {
+            key.getConstructor();
+        } catch (Throwable e) {
+            key = monkeyTryingKey();
+            if (key != null) {
+                Log.w(TAG, "monkey trying ResourcesKey success");
+            }
+        }
+        return key;
+    }
+
+    private static BaseKey monkeyTryingKey() {
+        BaseKey key = null;
+        for (int i = 0; ; i++) {
+            try {
+                if (i == 0) {
+                    key = new Customized.A();
+                } else if (i == 1) {
+                    key = new Customized.B();
+                } else if (i == 2) {
+                    key = new Customized.C();
+                } else {
+                    break;
+                }
+                key.getConstructor();
+            } catch (Throwable ignore) {
+                key = null;
+                continue;
+            }
+            break;
+        }
+        return key;
+    }
+
+
+    private abstract static class BaseKey {
+        static final Class ResourcesKeyClazz;
+        static final Field mResDirField;
+
+        static {
+            try {
+                Class rkc; // monkey check the resources key class
+                try {
+                    rkc = Class.forName("android.content.res.ResourcesKey");
+                } catch (Exception ignore) {
+                    rkc = Class.forName("android.app.ActivityThread$ResourcesKey");
+                }
+                ResourcesKeyClazz = rkc;
+                mResDirField = findField(ResourcesKeyClazz, "mResDir");
+            } catch (Exception ignore) {
+                throw new RuntimeException(ignore);
+            }
+        }
+
+        String resDir;
+
+        abstract Constructor getConstructor() throws Exception;
+
+        Object getNewKey(Object oldKey, String newResDir) throws Exception {
+            this.resDir = newResDir;
+            return null;
+        }
+    }
+
+    private abstract static class CommonKey extends BaseKey {
+        static final Field mDisplayIdField;
+        static final Field mOverrideConfigurationField;
+
+        static {
+            try {
+                mDisplayIdField = findField(ResourcesKeyClazz, "mDisplayId");
+                mOverrideConfigurationField = findField(ResourcesKeyClazz, "mOverrideConfiguration");
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        }
+
+        int displayId;
+        Configuration configuration;
+
+        @Override
+        Object getNewKey(Object oldKey, String newResDir) throws Exception {
+            super.getNewKey(oldKey, newResDir);
+            displayId = (int) mDisplayIdField.get(oldKey);
+            configuration = (Configuration) mOverrideConfigurationField.get(oldKey);
+            return null;
+        }
+    }
+
+    private static final class V24 extends CommonKey {
+        static final Field mSplitResDirsField;
+        static final Field mOverlayDirsField;
+        static final Field mLibDirsField;
+        static final Field mCompatInfoField;
+
+        static {
+            try {
+                mSplitResDirsField = findField(ResourcesKeyClazz, "mSplitResDirs");
+                mOverlayDirsField = findField(ResourcesKeyClazz, "mOverlayDirs");
+                mLibDirsField = findField(ResourcesKeyClazz, "mLibDirs");
+                mCompatInfoField = findField(ResourcesKeyClazz, "mCompatInfo");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        Constructor getConstructor() throws Exception {
+            Class CompatibilityInfoClazz = Class.forName("android.content.res.CompatibilityInfo");
+            Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                    String.class, String[].class, String[].class, String[].class, int.class, Configuration.class, CompatibilityInfoClazz);
+            cst.setAccessible(true);
+            return cst;
+        }
+
+        @Override
+        Object getNewKey(Object oldKey, String newResDir) throws Exception {
+            super.getNewKey(oldKey, newResDir);
+            String[] splitResDirs = (String[]) mSplitResDirsField.get(oldKey);
+            String[] overlayDirs = (String[]) mOverlayDirsField.get(oldKey);
+            String[] libDirs = (String[]) mLibDirsField.get(oldKey);
+            Object compatInfo = mCompatInfoField.get(oldKey);
+            return getConstructor()
+                    .newInstance(resDir, splitResDirs, overlayDirs, libDirs, displayId, configuration, compatInfo);
+        }
+    }
+
+    private static final class V23 extends CommonKey {
+        static final Field mScaleField;
+
+        static {
+            try {
+                mScaleField = findField(ResourcesKeyClazz, "mScale");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        Constructor getConstructor() throws Exception {
+            Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                    String.class, int.class, Configuration.class, float.class);
+            cst.setAccessible(true);
+            return cst;
+        }
+
+        @Override
+        Object getNewKey(Object oldKey, String newResDir) throws Exception {
+            super.getNewKey(oldKey, newResDir);
+            float scale = (float) mScaleField.get(oldKey);
+            return getConstructor()
+                    .newInstance(resDir, displayId, configuration, scale);
+        }
+    }
+
+    private static final class V19 extends CommonKey {
+        static final Field mScaleField;
+        static final Field mTokenField;
+
+        static {
+            try {
+                mScaleField = findField(ResourcesKeyClazz, "mScale");
+                mTokenField = findField(ResourcesKeyClazz, "mToken");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        Constructor getConstructor() throws Exception {
+            Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                    String.class, int.class, Configuration.class, float.class, IBinder.class);
+            cst.setAccessible(true);
+            return cst;
+        }
+
+        @Override
+        Object getNewKey(Object oldKey, String newResDir) throws Exception {
+            super.getNewKey(oldKey, newResDir);
+            float scale = (float) mScaleField.get(oldKey);
+            IBinder token = (IBinder) mTokenField.get(oldKey);
+            return getConstructor()
+                    .newInstance(resDir, displayId, configuration, scale, token);
+        }
+    }
+
+    /**
+     * the same as {@link V23}
+     */
+    private static final class V17 extends CommonKey {
+        static final Field mScaleField;
+
+        static {
+            try {
+                mScaleField = findField(ResourcesKeyClazz, "mScale");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        Constructor getConstructor() throws Exception {
+            Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                    String.class, int.class, Configuration.class, float.class);
+            cst.setAccessible(true);
+            return cst;
+        }
+
+        @Override
+        Object getNewKey(Object oldKey, String newResDir) throws Exception {
+            super.getNewKey(oldKey, newResDir);
+            float scale = (float) mScaleField.get(oldKey);
+            return getConstructor()
+                    .newInstance(resDir, displayId, configuration, scale);
+        }
+    }
+
+    private static final class V16 extends BaseKey {
+        static final Field mScaleField;
+
+        static {
+            try {
+                mScaleField = findField(ResourcesKeyClazz, "mScale");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        Constructor getConstructor() throws Exception {
+            Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                    String.class, float.class);
+            cst.setAccessible(true);
+            return cst;
+        }
+
+        @Override
+        Object getNewKey(Object oldKey, String newResDir) throws Exception {
+            super.getNewKey(oldKey, newResDir);
+            float scale = (float) mScaleField.get(oldKey);
+            return getConstructor()
+                    .newInstance(resDir, scale);
+        }
+    }
+
+
+    private static class Customized {
+
+        private static final class A extends CommonKey {
+            static final Field mScaleField;
+            static final Field mIsThemeableField;
+
+            static {
+                try {
+                    mScaleField = findField(ResourcesKeyClazz, "mScale");
+                    mIsThemeableField = findField(ResourcesKeyClazz, "mIsThemeable");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            Constructor getConstructor() throws Exception {
+                Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                        String.class, int.class, Configuration.class, float.class, boolean.class);
+                cst.setAccessible(true);
+                return cst;
+            }
+
+            @Override
+            Object getNewKey(Object oldKey, String newResDir) throws Exception {
+                super.getNewKey(oldKey, newResDir);
+                float scale = (float) mScaleField.get(oldKey);
+                boolean isThemeable = (boolean) mIsThemeableField.get(oldKey);
+                return getConstructor()
+                        .newInstance(resDir, displayId, configuration, scale, isThemeable);
+            }
+        }
+
+        private static final class B extends CommonKey {
+            static final Field mScaleField;
+            static final Field mTokenField;
+            static final Field mIsThemeableField;
+
+            static {
+                try {
+                    mScaleField = findField(ResourcesKeyClazz, "mScale");
+                    mTokenField = findField(ResourcesKeyClazz, "mToken");
+                    mIsThemeableField = findField(ResourcesKeyClazz, "mIsThemeable");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            Constructor getConstructor() throws Exception {
+                Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                        String.class, int.class, Configuration.class, float.class, IBinder.class, boolean.class);
+                cst.setAccessible(true);
+                return cst;
+            }
+
+            @Override
+            Object getNewKey(Object oldKey, String newResDir) throws Exception {
+                super.getNewKey(oldKey, newResDir);
+                float scale = (float) mScaleField.get(oldKey);
+                IBinder token = (IBinder) mTokenField.get(oldKey);
+                boolean isThemeable = (boolean) mIsThemeableField.get(oldKey);
+                return getConstructor()
+                        .newInstance(resDir, displayId, configuration, scale, token, isThemeable);
+            }
+        }
+
+        private static final class C extends CommonKey {
+            static final Field mScaleField;
+            static final Field mTokenField;
+            static final Field mIsThemeableField;
+
+            static {
+                try {
+                    mScaleField = findField(ResourcesKeyClazz, "mScale");
+                    mTokenField = findField(ResourcesKeyClazz, "mToken");
+                    mIsThemeableField = findField(ResourcesKeyClazz, "mIsThemeable");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            Constructor getConstructor() throws Exception {
+                Constructor cst = ResourcesKeyClazz.getDeclaredConstructor(
+                        String.class, int.class, Configuration.class, float.class, boolean.class, IBinder.class);
+                cst.setAccessible(true);
+                return cst;
+            }
+
+            @Override
+            Object getNewKey(Object oldKey, String newResDir) throws Exception {
+                super.getNewKey(oldKey, newResDir);
+                float scale = (float) mScaleField.get(oldKey);
+                IBinder token = (IBinder) mTokenField.get(oldKey);
+                boolean isThemeable = (boolean) mIsThemeableField.get(oldKey);
+                return getConstructor()
+                        .newInstance(resDir, displayId, configuration, scale, isThemeable, token);
+            }
+        }
 
     }
 
-    private static final class V19 {
-
-    }
-
-    private static final class V17 {
-
-    }
-
-    private static final class V7 {
-
-    }
 }

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareIntentUtil.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareIntentUtil.java
@@ -45,6 +45,7 @@ public class ShareIntentUtil {
     public static final  String INTENT_PATCH_SYSTEM_OTA          = "intent_patch_system_ota";
     public static final  String INTENT_PATCH_OAT_DIR             = "intent_patch_oat_dir";
     public static final  String INTENT_PATCH_INTERPRET_EXCEPTION = "intent_patch_interpret_exception";
+    public static final  String INTENT_PATCH_RUN_NEW_VERSION     = "intent_patch_run_new_version";
 
 
     private static final String TAG                              = "ShareIntentUtil";


### PR DESCRIPTION
一、动态插件技术可能会在Application启动时将插件资源注入AssetManager并更新到缓存的Resource对象，以便接下来启动的组件能通过缓存获取插件资源。当Tinker执行热修复后，LoadedApk#resDir变更成修复包路径，新启动组件使用该路径生成的key，无法从Resource缓存中找value，即那个被注入插件资源的Resource，于是在使用插件时抛出资源查找异常。
**>> 在热修复更新Resource缓存时，顺便更新它们的ResourcesKey，可以避免Resource重建，解决上述问题。**

二、Tinker在主进程启动时检查是否存在新补丁，若存在则立即加载，并杀死其它进程。这保证了新补丁的快速生效。不过对于一些应用，比如音乐播放器，考虑这样一个场景：用户启动App，主进程拉取最新补丁-->用户选好歌曲并播放，home键并切换到其它App，留后台进程持续播歌-->一段时间后主进程被回收-->啊没有关系，老子就听个响-->点击图标或某些因素导致主进程重启，加载新补丁并杀死播放进程。此时就会出现声音突然停止的情况。
**>> 在TinkerLoader中提供一个可覆盖的方法，根据不同环境条件返回一个boolean值，用以指引主进程当次启动是否需要加载新补丁。**