### PR TITLE
fix(android): the logging tag was too long warning

### DIFF
--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerArkHotLoader.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerArkHotLoader.java
@@ -39,7 +39,7 @@ import dalvik.system.PathClassLoader;
  * pre-load patch dex files
  */
 public class TinkerArkHotLoader {
-    private static final String TAG = "Tinker.TinkerArkHotLoader";
+    private static final String TAG = "Tinker.ArkHotLoader";
 
     private static final String ARK_MEAT_FILE = ShareConstants.ARKHOT_META_FILE;
     private static final String ARKHOT_PATH = ShareConstants.ARKHOTFIX_PATH;


### PR DESCRIPTION
```
run `./gradlew check`
```

```
  Fix the issues identified by lint, or add the following to your build script to proceed with errors:
  ...
  android {
      lintOptions {
          abortOnError false
      }
  }
  ...

  The first 3 errors (out of 4) were:
  /Users/simsun/opensource/android/tinker/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerArkHotLoader.java:64: Error: The logging tag can be at most 23 characters, was 25 (Tinker.TinkerArkHotLoader) [LongLogTag]
              Log.w(TAG, "there is no apk to load");
                    ~~~
  /Users/simsun/opensource/android/tinker/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerArkHotLoader.java:70: Error: The logging tag can be at most 23 characters, was 25 (Tinker.TinkerArkHotLoader) [LongLogTag]
              Log.i(TAG, "classloader: " + classLoader.toString());
                    ~~~
  /Users/simsun/opensource/android/tinker/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerArkHotLoader.java:72: Error: The logging tag can be at most 23 characters, was 25 (Tinker.TinkerArkHotLoader) [LongLogTag]
              Log.e(TAG, "classloader is null");
                    ~~~
```