### PR TITLE
Fix interception of dex re-optimizating.

### DIFF
--- a/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/listener/DefaultPatchListener.java
+++ b/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/listener/DefaultPatchListener.java
@@ -124,31 +124,33 @@ public class DefaultPatchListener implements PatchListener {
             return ShareConstants.ERROR_PATCH_JIT;
         }
 
-        Tinker tinker = Tinker.with(context);
+        final TinkerLoadResult loadResult = manager.getTinkerLoadResultIfPresent();
+        // only call repair on main process
+        final boolean repairOptNeeded = manager.isMainProcess()
+                && loadResult != null && loadResult.optimizeOverdue;
 
-        if (tinker.isTinkerLoaded()) {
-            TinkerLoadResult tinkerLoadResult = tinker.getTinkerLoadResultIfPresent();
-            if (tinkerLoadResult != null && !tinkerLoadResult.useInterpretMode) {
-                String currentVersion = tinkerLoadResult.currentVersion;
+        if (!repairOptNeeded) {
+            if (manager.isTinkerLoaded() && loadResult != null) {
+                String currentVersion = loadResult.currentVersion;
                 if (patchMd5.equals(currentVersion)) {
                     return ShareConstants.ERROR_PATCH_ALREADY_APPLY;
                 }
             }
-        }
 
-        // Hit if we have already applied patch but main process did not restart.
-        final String patchDirectory = manager.getPatchDirectory().getAbsolutePath();
-        File patchInfoLockFile = SharePatchFileUtil.getPatchInfoLockFile(patchDirectory);
-        File patchInfoFile = SharePatchFileUtil.getPatchInfoFile(patchDirectory);
-        try {
-            final SharePatchInfo currInfo = SharePatchInfo.readAndCheckPropertyWithLock(patchInfoFile, patchInfoLockFile);
-            if (currInfo != null && !ShareTinkerInternals.isNullOrNil(currInfo.newVersion) && !currInfo.isRemoveNewVersion) {
-                if (patchMd5.equals(currInfo.newVersion)) {
-                    return ShareConstants.ERROR_PATCH_ALREADY_APPLY;
+            // Hit if we have already applied patch but main process did not restart.
+            final String patchDirectory = manager.getPatchDirectory().getAbsolutePath();
+            File patchInfoLockFile = SharePatchFileUtil.getPatchInfoLockFile(patchDirectory);
+            File patchInfoFile = SharePatchFileUtil.getPatchInfoFile(patchDirectory);
+            try {
+                final SharePatchInfo currInfo = SharePatchInfo.readAndCheckPropertyWithLock(patchInfoFile, patchInfoLockFile);
+                if (currInfo != null && !ShareTinkerInternals.isNullOrNil(currInfo.newVersion) && !currInfo.isRemoveNewVersion) {
+                    if (patchMd5.equals(currInfo.newVersion)) {
+                        return ShareConstants.ERROR_PATCH_ALREADY_APPLY;
+                    }
                 }
+            } catch (Throwable ignored) {
+                // Ignored.
             }
-        } catch (Throwable ignored) {
-            // Ignored.
         }
 
         if (!UpgradePatchRetry.getInstance(context).onPatchListenerCheck(patchMd5)) {

--- a/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/tinker/TinkerLoadResult.java
+++ b/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/tinker/TinkerLoadResult.java
@@ -49,6 +49,8 @@ public class TinkerLoadResult {
 
     public boolean systemOTA;
 
+    public boolean optimizeOverdue;
+
     //@Nullable
     public File                    patchVersionDirectory;
     //@Nullable
@@ -80,6 +82,7 @@ public class TinkerLoadResult {
         systemOTA = ShareIntentUtil.getBooleanExtra(intentResult, ShareIntentUtil.INTENT_PATCH_SYSTEM_OTA, false);
         oatDir = ShareIntentUtil.getStringExtra(intentResult, ShareIntentUtil.INTENT_PATCH_OAT_DIR);
         useInterpretMode = ShareConstants.INTERPRET_DEX_OPTIMIZE_PATH.equals(oatDir);
+        optimizeOverdue = systemOTA || useInterpretMode;
 
         final boolean isMainProcess = tinker.isMainProcess();
 
@@ -222,6 +225,7 @@ public class TinkerLoadResult {
                 if (dexOptPath != null) {
                     //we only pass one missing file
                     TinkerLog.e(TAG, "patch dex opt file not found:%s", dexOptPath);
+                    optimizeOverdue = true;
                     tinker.getLoadReporter().onLoadFileNotFound(new File(dexOptPath),
                         ShareConstants.TYPE_DEX_OPT, false);
 


### PR DESCRIPTION
在DefaultPatchListener#patchCheck()中，判断到目标patch.Md5与patchInfoFile.newVersion相同就拦截的话，应该会导致那些丢失了oat文件、或需要以InterpretMode执行（无论成功与失败）的patch始终不能得到高性能优化。在收到新的补丁之前，它将一直以解释模式运行。
在我的项目里发现这个问题。然而我不确定按官方建议方式接入的、完整的tinker项目是否有规避这个问题。希望有空能审查一下。
感谢~