### PR TITLE
chore(build): change min sdk to 14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 }
 
 ext {
-    minSdkVersion = 10
+    minSdkVersion = 14
     compileSdkVersion = 26
     targetSdkVersion = 23
     buildToolsVersion = '28.0.3'


### PR DESCRIPTION
Basedexclassloader needs minsdk 14
```
NewClassLoaderInjector.java:139: Error: Class requires API level 14 (current min is 10): dalvik.system.BaseDexClassLoader [NewApi]
          final Field pathListField = findField(BaseDexClassLoader.class, "pathList");
                                                ~~~~~~~~~~~~~~~~~~
```

TEST PLAN:

pass `./gradlew check`