### PR TITLE
Annotations with identical EncodedValues but different visibilities are

### DIFF
--- a/third-party/aosp-dexutils/src/main/java/com/tencent/tinker/android/dex/Annotation.java
+++ b/third-party/aosp-dexutils/src/main/java/com/tencent/tinker/android/dex/Annotation.java
@@ -17,6 +17,7 @@
 package com.tencent.tinker.android.dex;
 
 import com.tencent.tinker.android.dex.TableOfContents.Section.Item;
+import com.tencent.tinker.android.dex.util.CompareUtils;
 import com.tencent.tinker.android.dex.util.HashCodeHelper;
 
 import static com.tencent.tinker.android.dex.EncodedValueReader.ENCODED_ANNOTATION;
@@ -45,7 +46,9 @@ public final class Annotation extends Item<Annotation> {
     }
 
     @Override public int compareTo(Annotation other) {
-        return encodedAnnotation.compareTo(other.encodedAnnotation);
+        int cmpRes = encodedAnnotation.compareTo(other.encodedAnnotation);
+        if (cmpRes != 0) return cmpRes;
+        return CompareUtils.uCompare(visibility, other.visibility);
     }
 
     @Override


### PR DESCRIPTION
no longer viewed as the same Annotation during patch generation.

I recently had a situation where, when Tinker was generating a patch, it would discover two Annotations that had identical EncodeValues, but with different visibilities, and accidentally think they were the same and combine them in the dex.  The result was when Tinker went to verify the patch my simulating it, it would find classes that referenced annotations with the wrong visibility.

My fix for the issue was to edit the Annotation classes `compareTo` to take into account visibility, should the EncodedValues be identical.