### PR TITLE
fix: No such property: variantConfiguration

### DIFF
--- a/tinker-sample-android/build.gradle
+++ b/tinker-sample-android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         if (project.hasProperty('GRADLE_3') && GRADLE_3.equalsIgnoreCase('TRUE')) {
-            classpath 'com.android.tools.build:gradle:4.0.0-alpha09'
+            classpath 'com.android.tools.build:gradle:3.5.3'
         } else {
             classpath 'com.android.tools.build:gradle:2.3.3'
         }


### PR DESCRIPTION
fix :  issure[1357](https://github.com/Tencent/tinker/issues/1357)

the gradle 4.0.0-alpha09 may cause  "No such property: variantConfiguration"
according to the document : [gradle-plugin](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle), set gradle version to 3.5.3