### PR TITLE
修复热修后 SharedLibrary R 类中的资源 ID 与 AssetManager 中 Package ID 不一致导致的资源找不到问题

### DIFF
--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerResourcePatcher.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerResourcePatcher.java
@@ -24,6 +24,8 @@ import android.os.Build;
 import android.util.ArrayMap;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.tencent.tinker.loader.shareutil.ShareConstants;
 import com.tencent.tinker.loader.shareutil.SharePatchFileUtil;
 import com.tencent.tinker.loader.shareutil.ShareReflectUtil;
@@ -57,6 +59,7 @@ class TinkerResourcePatcher {
 
     // method
     private static Method addAssetPathMethod = null;
+    private static Method addAssetPathAsSharedLibraryMethod = null;
     private static Method ensureStringBlocksMethod = null;
 
     // field
@@ -95,6 +98,10 @@ class TinkerResourcePatcher {
         // Create a new AssetManager instance and point it to the resources
         final AssetManager assets = context.getAssets();
         addAssetPathMethod = findMethod(assets, "addAssetPath", String.class);
+        if (shouldAddSharedLibraryAssets(context.getApplicationInfo())) {
+            addAssetPathAsSharedLibraryMethod =
+                    findMethod(assets, "addAssetPathAsSharedLibrary", String.class);
+        }
 
         // Kitkat needs this method call, Lollipop doesn't. However, it doesn't seem to cause any harm
         // in L, so we do it unconditionally.
@@ -199,6 +206,20 @@ class TinkerResourcePatcher {
             throw new IllegalStateException("Could not create new AssetManager");
         }
 
+        // Add SharedLibraries to AssetManager for resolve system resources not found issue
+        // This influence SharedLibrary Package ID
+        if (shouldAddSharedLibraryAssets(appInfo)) {
+            for (String sharedLibrary : appInfo.sharedLibraryFiles) {
+                if (!sharedLibrary.endsWith(".apk")) {
+                    continue;
+                }
+                if (((Integer) addAssetPathAsSharedLibraryMethod.invoke(newAssetManager, sharedLibrary)) == 0) {
+                    throw new IllegalStateException("AssetManager add SharedLibrary Fail");
+                }
+                Log.i(TAG, "addAssetPathAsSharedLibrary " + sharedLibrary);
+            }
+        }
+
         // Kitkat needs this method call, Lollipop doesn't. However, it doesn't seem to cause any harm
         // in L, so we do it unconditionally.
         if (stringBlocksField != null && ensureStringBlocksMethod != null) {
@@ -286,5 +307,10 @@ class TinkerResourcePatcher {
         }
         Log.i(TAG, "checkResUpdate success, found test resource assets file " + TEST_ASSETS_VALUE);
         return true;
+    }
+
+    private static boolean shouldAddSharedLibraryAssets(@NonNull ApplicationInfo applicationInfo) {
+        return SDK_INT >= Build.VERSION_CODES.N && applicationInfo != null &&
+                applicationInfo.sharedLibraryFiles != null;
     }
 }


### PR DESCRIPTION
在一些手机中，应用会使用系统的 SharedLibrary； Tinker 热修后没有考虑 SharedLibrary「SharedLibrary 资源 Package ID 由 AssetManager2 动态分配，一般从 0x02 开始」；这样导致加载 WebView 等时分配的 Package ID 「分配后会重写 WebView 中 R 类的成员值」会与普通的 Activity 等上下文「直接使用 ApplicationInfo  创建会考虑 SharedLibrary」中 WebView Package ID 不一致；从未导致使用 WebView 时发生 Resources$NotFoundException 错误