### PR TITLE
修改applicationid获取的方式，避免设置flavors后applicationid不对

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
@@ -186,7 +186,7 @@ class TinkerPatchPlugin implements Plugin<Project> {
 
                 //resource id
                 TinkerResourceIdTask applyResourceTask = mProject.tasks.create("tinkerProcess${variantName}ResourceId", TinkerResourceIdTask)
-                applyResourceTask.applicationId = variant.mergedFlavor.applicationId
+                applyResourceTask.applicationId = variantData.getApplicationId()
                 applyResourceTask.variantName = variant.name
                 applyResourceTask.resDir = resDir
 


### PR DESCRIPTION
如果使用项目中使用了flavors，如下：

`
flavorDimensions "default"

productFlavors {
    free {
         dimension "default"
        applicationIdSuffix ".free"
     }
    pro {
        dimension "default"
        applicationIdSuffix ".pro"
    }
}
`

在构建特定flavor的补丁时，比如执行./gradlew tinkerPatchFreeDebug，使用variant.mergedFlavor.applicationId获取的applicationId并不会带上指定的applicationIdSuffix后缀。会导致生成的public.txt文件中applicationid和基线包不一致，导致构建基线包异常。

