### PR TITLE
upgrade androidX should add `android.enableJetifier=true`

### DIFF
--- a/tinker-sample-android/gradle.properties
+++ b/tinker-sample-android/gradle.properties
@@ -22,3 +22,4 @@ GRADLE_3=true
 
 #tinker.aapt2.public=false
 android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
if `android.enableJetifier=false will throw exception
> Task :app:compileDebugJavaWithJavac FAILED
Gradle may disable incremental compilation as the following annotation processors are not incremental: tinker-android-anno-1.9.14.5.jar (com.tencent.tinker:tinker-android-anno:1.9.14.5).
Consider setting the experimental feature flag android.enableSeparateAnnotationProcessing=true in the gradle.properties file to run annotation processing in a separate task and make compilation incremental.
错误: 无法访问Keep
  找不到android.support.annotation.Keep的类文件
1 个错误