### PR TITLE
[tinker] Support JDK 12+

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
@@ -16,7 +16,6 @@
 
 package com.tencent.tinker.build.gradle
 
-
 import com.tencent.tinker.build.gradle.extension.*
 import com.tencent.tinker.build.gradle.task.*
 import com.tencent.tinker.build.util.FileOperation
@@ -28,9 +27,9 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.jetbrains.annotations.NotNull
+import sun.misc.Unsafe
 
 import java.lang.reflect.Field
-import java.lang.reflect.Modifier
 
 /**
  * Registers the plugin's tasks.
@@ -450,11 +449,11 @@ class TinkerPatchPlugin implements Plugin<Project> {
 
     void replaceKotlinFinalField(String className, String filedName, Object instance, Object fieldValue) {
         Field field = Class.forName(className).getDeclaredField(filedName)
-        Field modifiersField = Field.class.getDeclaredField("modifiers")
-        modifiersField.setAccessible(true)
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL)
-        field.setAccessible(true)
-        field.set(instance, fieldValue)
+        final Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe")
+        unsafeField.setAccessible(true)
+        final Unsafe unsafe = (Unsafe) unsafeField.get(null)
+        final long fieldOffset = unsafe.objectFieldOffset(field)
+        unsafe.putObject(instance, fieldOffset, fieldValue)
     }
 
     File getManifestMultiDexKeepProguard(def applicationVariant) {


### PR DESCRIPTION
Use Unsafe to replace final field. Because change modifiers with reflection is not allowed on Java 12+.