### PR TITLE
修复加固模式构建出的patch包客户端加载不了的bug 

### DIFF
--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/DexDiffDecoder.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/DexDiffDecoder.java
@@ -187,6 +187,17 @@ public class DexDiffDecoder extends BaseDecoder {
         } catch (Exception e) {
             e.printStackTrace();
         }
+        
+        // If is protechted app mode.
+        // Just collect current old dex file and corresponding new dex file for further processing.
+        if (config.mIsProtectedApp) {
+            hasDexChanged = true;
+            oldAndNewDexFilePairList.add(new AbstractMap.SimpleEntry<>(oldFile, newFile));
+            if (oldFile != null && oldFile.exists() && oldFile.length() > 0) {
+                oldDexFiles.add(oldFile);
+            }
+            return true;
+        }     
 
         // If corresponding new dex was completely deleted, just return false.
         // don't process 0 length dex


### PR DESCRIPTION
## bug产生的场景

old apk有5个dex，classes.dex ... classes4.dex, new apk 有6 个dex, classes.dex ... classes5.dex。当计算classes5.dex的变更的时候，因为classes5.dex没有在old apk中存在，所以就直接把classes5.dex[写入最终的patch包中了](          https://github.com/Tencent/tinker/blob/d7c7e607bcac34fef24dcd298e6839566b5c88a1/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/DexDiffDecoder.java#L203)

相关日志如下：
```
DexDecoder:add newly dex file: 
DexDecoder:write meta file data: classes5.dex,,81d839f97245fb1ea48fb6e2ed387c94,81d839f97245fb1ea48fb6e2ed387c94,0,0,3963140505,raw
```
当开启加固模式时，patch的构建需要计算出变更的类有哪些，当变更的类比较多且产生大于6个dex文件的时候，可能会[覆写之前的classes5.dex](https://github.com/Tencent/tinker/blob/d7c7e607bcac34fef24dcd298e6839566b5c88a1/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/DexDiffDecoder.java#L492)，最终导致客户端在加载patch时验证dex的md5失败。

相关日志:
```
DexDecoder:write changed classes dex meta file data:
classes.dex,,e2ebdecaf1636729cd40465079f0e1b2,e2ebdecaf1636729cd40465079f0e1b2,0,0,0,jar
classes2.dex,,26a6391a44fdb810caf60cb39ea388e1,26a6391a44fdb810caf60cb39ea388e1,0,0,0,jar
classes3.dex,,2d3ae5cc031e81a394ad48c284ba31ba,2d3ae5cc031e81a394ad48c284ba31ba,0,0,0,jar
classes4.dex,,6bd67e2f3b4fd8645392de908622f20f,6bd67e2f3b4fd8645392de908622f20f,0,0,0,jar
classes5.dex,,8255f4a31fc4c6f89951ee8baa637d3c,8255f4a31fc4c6f89951ee8baa637d3c,0,0,0,jar
classes6.dex,,7e56dac5cb76af12743ed7b2ec432971,7e56dac5cb76af12743ed7b2ec432971,0,0,0,jar
classes7.dex,,cba6b04d063e1e59eff87c2896cfd888,cba6b04d063e1e59eff87c2896cfd888,0,0,0,jar
classes8.dex,,45311a240a4c4db61ee51a361030b9ae,45311a240a4c4db61ee51a361030b9ae,0,0,0,jar
```

patch中的dex_meta.txt
```
classes5.dex,,81d839f97245fb1ea48fb6e2ed387c94,81d839f97245fb1ea48fb6e2ed387c94,0,0,3963140505,jar
classes.dex,,6b1ea167ee2d5d063f82e381e535ac98,6b1ea167ee2d5d063f82e381e535ac98,0,0,0,jar
classes2.dex,,2d3ae5cc031e81a394ad48c284ba31ba,2d3ae5cc031e81a394ad48c284ba31ba,0,0,0,jar
classes3.dex,,7e56dac5cb76af12743ed7b2ec432971,7e56dac5cb76af12743ed7b2ec432971,0,0,0,jar
classes4.dex,,45311a240a4c4db61ee51a361030b9ae,45311a240a4c4db61ee51a361030b9ae,0,0,0,jar
classes5.dex,,6bd67e2f3b4fd8645392de908622f20f,6bd67e2f3b4fd8645392de908622f20f,0,0,0,jar
classes6.dex,,e2ebdecaf1636729cd40465079f0e1b2,e2ebdecaf1636729cd40465079f0e1b2,0,0,0,jar
classes7.dex,,cba6b04d063e1e59eff87c2896cfd888,cba6b04d063e1e59eff87c2896cfd888,0,0,0,jar
classes8.dex,,8255f4a31fc4c6f89951ee8baa637d3c,8255f4a31fc4c6f89951ee8baa637d3c,0,0,0,jar

test.dex,,56900442eb5b7e1de45449d0685e6e00,56900442eb5b7e1de45449d0685e6e00,0,0,0,jar
```