### PR TITLE
fix bug for #1525 #1508 

### DIFF
--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/ApkDecoder.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/ApkDecoder.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.regex.Matcher;
 
 /**
  * Created by zhangshaowen on 16/3/15.
@@ -222,7 +223,7 @@ public class ApkDecoder extends BaseDecoder {
         }
 
         private String getAbiFromPath(String path) {
-            path = path.replaceAll(File.separator, "/");
+            path = path.replaceAll(Matcher.quoteReplacement(File.separator), "/");
             final int prefixPos = path.indexOf("/lib/");
             if (prefixPos < 0) {
                 return null;


### PR DESCRIPTION
fix bug for #1525 #1508 

windows file path 分隔符正则替换问题，由于 java 的 String replaceAll 方法第一个参数是正则表达式，故而要经过两次转义，一次Java、一次正则，所以原来直接`File.separator`在 windows 下存在兼容问题，修正为`Matcher.quoteReplacement(File.separator)`兼容。