### PR TITLE
fixbug #1549 tinkerId not updated.

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/Compatibilities.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/Compatibilities.groovy
@@ -67,6 +67,10 @@ class Compatibilities {
         return project.tasks.findByName("merge${variant.name.capitalize()}Resources")
     }
 
+    static def getProcessManifestForPackageTask(project, variant) {
+        return project.tasks.findByName("process${variant.name.capitalize()}ManifestForPackage")
+    }
+
     static def getProcessResourcesTask(project, variant) {
         return project.tasks.findByName("process${variant.name.capitalize()}Resources")
     }

--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/TinkerPatchPlugin.groovy
@@ -171,6 +171,10 @@ class TinkerPatchPlugin implements Plugin<Project> {
 
                 def agpProcessResourcesTask = Compatibilities.getProcessResourcesTask(project, variant)
                 agpProcessResourcesTask.dependsOn tinkerManifestTask
+                def agpProcessManifestPackageTask = Compatibilities.getProcessManifestForPackageTask(project, variant)
+                if (agpProcessManifestPackageTask != null) {
+                    agpProcessManifestPackageTask.dependsOn tinkerManifestTask
+                }
 
                 //resource id
                 TinkerResourceIdTask applyResourceTask = mProject.tasks.create("tinkerProcess${capitalizedVariantName}ResourceId", TinkerResourceIdTask)


### PR DESCRIPTION
#1549

开启并行构建及缓存能力后，多次提交变更代码（TinkerId=渠道号_版本号_gitCommitId）的情况下，最终 base apk 产物的 TinkerId 会概率性出现没用最新 gitCommitId，还是上次构建缓存的，经过分析发现是 task 依赖存在问题导致，修复后以批量多渠道上线验证没问题。