### PR TITLE
[tinker] Fix log output error

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerPatchSchemaTask.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerPatchSchemaTask.groovy
@@ -19,7 +19,6 @@ package com.tencent.tinker.build.gradle.task
 import com.tencent.tinker.build.gradle.extension.TinkerPatchExtension
 import com.tencent.tinker.build.patch.InputParam
 import com.tencent.tinker.build.patch.Runner
-import groovy.io.FileType
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
@@ -121,7 +120,8 @@ public class TinkerPatchSchemaTask extends DefaultTask {
 
             builder.setOldApk(oldApk.getAbsolutePath())
                     .setNewApk(newApk.getAbsolutePath())
-                    .setOutBuilder(tmpDir.getAbsolutePath())
+                    .setOutBuilder(outputDir.getAbsolutePath())
+                    .setTmpBuilder(tmpDir.getAbsolutePath())
                     .setIgnoreWarning(configuration.ignoreWarning)
                     .setAllowLoaderInAnyDex(configuration.allowLoaderInAnyDex)
                     .setRemoveLoaderForAllDex(configuration.removeLoaderForAllDex)
@@ -145,15 +145,6 @@ public class TinkerPatchSchemaTask extends DefaultTask {
 
             InputParam inputParam = builder.create()
             Runner.gradleRun(inputParam)
-
-            def prefix = newApk.name.take(newApk.name.lastIndexOf('.'))
-            tmpDir.eachFile(FileType.FILES) {
-                if (!it.name.endsWith(".apk")) {
-                    return
-                }
-                final File dest = new File(outputDir, "${prefix}-${it.name}")
-                it.renameTo(dest)
-            }
         }
     }
 }

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/BaseDecoder.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/BaseDecoder.java
@@ -36,7 +36,7 @@ public abstract class BaseDecoder {
 
     public BaseDecoder(Configuration config) throws IOException {
         this.config = config;
-        this.outDir = new File(config.mOutFolder);
+        this.outDir = new File(config.mTmpFolder);
 
         this.resultDir = config.mTempResultDir;
 

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/BsDiffDecoder.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/BsDiffDecoder.java
@@ -45,7 +45,7 @@ public class BsDiffDecoder extends BaseDecoder {
         }
 
         if (logPath != null) {
-            logWriter = new InfoWriter(config, config.mOutFolder + File.separator + logPath);
+            logWriter = new InfoWriter(config, config.mTmpFolder + File.separator + logPath);
         } else {
             logWriter = null;
         }

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/DexDiffDecoder.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/DexDiffDecoder.java
@@ -111,7 +111,7 @@ public class DexDiffDecoder extends BaseDecoder {
         }
 
         if (logPath != null) {
-            logWriter = new InfoWriter(config, config.mOutFolder + File.separator + logPath);
+            logWriter = new InfoWriter(config, config.mTmpFolder + File.separator + logPath);
         } else {
             logWriter = null;
         }
@@ -614,7 +614,7 @@ public class DexDiffDecoder extends BaseDecoder {
     }
 
     private void diffDexPairAndFillRelatedInfo(File oldDexFile, File newDexFile, RelatedInfo relatedInfo) {
-        File tempFullPatchDexPath = new File(config.mOutFolder + File.separator + TypedValue.DEX_TEMP_PATCH_DIR);
+        File tempFullPatchDexPath = new File(config.mTmpFolder + File.separator + TypedValue.DEX_TEMP_PATCH_DIR);
         final String dexName = getRelativeDexName(oldDexFile, newDexFile);
 
         File dexDiffOut = getOutputPath(newDexFile).toFile();

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/ResDiffDecoder.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/decoder/ResDiffDecoder.java
@@ -81,7 +81,7 @@ public class ResDiffDecoder extends BaseDecoder {
         }
 
         if (logPath != null) {
-            logWriter = new InfoWriter(config, config.mOutFolder + File.separator + logPath);
+            logWriter = new InfoWriter(config, config.mTmpFolder + File.separator + logPath);
         } else {
             logWriter = null;
         }
@@ -348,12 +348,12 @@ public class ResDiffDecoder extends BaseDecoder {
         // last add test res in assets for user cannot ignore it;
         addAssetsFileForTestResource();
 
-        File tempResZip = new File(config.mOutFolder + File.separator + TEMP_RES_ZIP);
+        File tempResZip = new File(config.mTmpFolder + File.separator + TEMP_RES_ZIP);
         final File tempResFiles = config.mTempResultDir;
 
         //gen zip resources_out.zip
         FileOperation.zipInputDir(tempResFiles, tempResZip, null);
-        File extractToZip = new File(config.mOutFolder + File.separator + TypedValue.RES_OUT);
+        File extractToZip = new File(config.mTmpFolder + File.separator + TypedValue.RES_OUT);
 
         String resZipMd5 = Utils.genResOutputFile(extractToZip, tempResZip, config,
             addedSet, modifiedSet, deletedSet, largeModifiedSet, largeModifiedMap);

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/patch/Configuration.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/patch/Configuration.java
@@ -90,6 +90,7 @@ public class Configuration {
      */
     public String  mOldApkPath;
     public String  mNewApkPath;
+    public String  mTmpFolder;
     public String  mOutFolder;
     public File    mOldApkFile;
     public File    mNewApkFile;
@@ -172,7 +173,8 @@ public class Configuration {
         mResIgnoreChangeWarningPattern = new HashSet<>();
 
         mPackageFields = new HashMap<>();
-        mOutFolder = outputFile.getAbsolutePath();
+        mTmpFolder = outputFile.getAbsolutePath();
+        mOutFolder = mTmpFolder;
         FileOperation.cleanDir(outputFile);
 
         mOldApkFile = oldApkFile;
@@ -241,6 +243,7 @@ public class Configuration {
         mNewApkPath = param.newApk;
         mNewApkFile = new File(mNewApkPath);
 
+        mTmpFolder = param.tmpFolder;
         mOutFolder = param.outFolder;
 
         mIgnoreWarning = param.ignoreWarning;
@@ -259,7 +262,7 @@ public class Configuration {
         mUseSignAPk = param.useSign;
         setSignData(param.signFile, param.keypass, param.storealias, param.storepass);
 
-        FileOperation.cleanDir(new File(mOutFolder));
+        FileOperation.cleanDir(new File(mTmpFolder));
 
         createTempDirectory();
         checkInputPatternParameter();
@@ -274,7 +277,7 @@ public class Configuration {
         sb.append("configuration: \n");
         sb.append("oldApk:" + mOldApkPath + "\n");
         sb.append("newApk:" + mNewApkPath + "\n");
-        sb.append("outputFolder:" + mOutFolder + "\n");
+        sb.append("outputFolder:" + mTmpFolder + "\n");
         sb.append("isIgnoreWarning:" + mIgnoreWarning + "\n");
         sb.append("isAllowLoaderClassInAnyDex:" + mAllowLoaderInAnyDex + "\n");
         sb.append("isRemoveLoaderForAllDex:" + mRemoveLoaderForAllDex + "\n");
@@ -326,7 +329,7 @@ public class Configuration {
     }
 
     private void createTempDirectory() throws TinkerPatchException {
-        mTempResultDir = new File(mOutFolder + File.separator + TypedValue.PATH_PATCH_FILES);
+        mTempResultDir = new File(mTmpFolder + File.separator + TypedValue.PATH_PATCH_FILES);
         FileOperation.deleteDir(mTempResultDir);
         if (!mTempResultDir.exists()) {
             mTempResultDir.mkdir();
@@ -357,8 +360,8 @@ public class Configuration {
             tempNewName += "-new";
         }
 
-        mTempUnzipOldDir = new File(mOutFolder, tempOldName);
-        mTempUnzipNewDir = new File(mOutFolder, tempNewName);
+        mTempUnzipOldDir = new File(mTmpFolder, tempOldName);
+        mTempUnzipNewDir = new File(mTmpFolder, tempNewName);
     }
 
     public void setSignData(File signatureFile, String keypass, String storealias, String storepass) throws IOException {

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/patch/InputParam.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/patch/InputParam.java
@@ -29,6 +29,7 @@ public class InputParam {
      */
     public final String  oldApk;
     public final String  newApk;
+    public final String  tmpFolder;
     public final String  outFolder;
     public final File    signFile;
     public final String  keypass;
@@ -91,6 +92,7 @@ public class InputParam {
     private InputParam(
             String oldApk,
             String newApk,
+            String tmpFolder,
             String outFolder,
             File signFile,
             String keypass,
@@ -116,12 +118,13 @@ public class InputParam {
             boolean useApplyResource,
             HashMap<String, String> configFields,
 
-        String sevenZipPath,
-        String arkHotPatchPath,
-        String arkHotPatchName
+            String sevenZipPath,
+            String arkHotPatchPath,
+            String arkHotPatchName
     ) {
         this.oldApk = oldApk;
         this.newApk = newApk;
+        this.tmpFolder = tmpFolder;
         this.outFolder = outFolder;
         this.signFile = signFile;
         this.keypass = keypass;
@@ -159,6 +162,7 @@ public class InputParam {
          */
         private String  oldApk;
         private String  newApk;
+        private String  tmpFolder;
         private String  outFolder;
         private File    signFile;
         private String  keypass;
@@ -267,6 +271,11 @@ public class InputParam {
             return this;
         }
 
+        public Builder setTmpBuilder(String tmpFolder) {
+            this.tmpFolder = tmpFolder;
+            return this;
+        }
+
         public Builder setOutBuilder(String outFolder) {
             this.outFolder = outFolder;
             return this;
@@ -361,6 +370,7 @@ public class InputParam {
             return new InputParam(
                     oldApk,
                     newApk,
+                    tmpFolder,
                     outFolder,
                     signFile,
                     keypass,

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/Logger.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/Logger.java
@@ -29,7 +29,7 @@ public class Logger {
     private static InfoWriter logWriter;
 
     public static void initLogger(Configuration config) throws IOException {
-        String logPath = config.mOutFolder + File.separator + TypedValue.FILE_LOG;
+        String logPath = config.mTmpFolder + File.separator + TypedValue.FILE_LOG;
         logWriter = new InfoWriter(config, logPath);
     }
 


### PR DESCRIPTION
当前日志显示输出的unsigned.apk、signed.apk、signed_7zip.apk位于build/tmp文件夹下（```PatchBuilder#buildPatch```），然而实际上在```TinkerPatchSchemaTask#tinkerPatch```的最后，将所有apk遍历放入了build/output文件夹，我花了一些时间才找到它们。

我注意到是在一个单独的提交中将apk移动了位置，同时为了兼容Command模式，因此增加了```outputDir```参数标记apk输出位置，原```outputDir```重命名为```tmpDir```标记中间产物的位置。


The current log displays the output of unsigned.apk, signed.apk and signed_ 7zip.apk is located in the build/tmp folder. However, they are actually in the build/output folder. It took me some time to find them.

I noticed that APK was moved in a separate commit, and in order to be compatible with Command mode. Therefore, the parameter  ```outputDir```  is added to mark the output position of APK, and the original ```outputdir``` is renamed to ```tmpDir``` to mark the position of intermediate product.

