### PR TITLE
Fix failed to write manifest in AGP 4.1.

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/Compatibilities.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/Compatibilities.groovy
@@ -28,6 +28,11 @@ class Compatibilities {
 
     static def getOutputManifestPath(project, manifestTask, variantOutput) {
         try {
+            return new File(manifestTask.packageManifests.get().asFile, "${variantOutput.dirName}/AndroidManifest.xml")
+        } catch (Throwable ignored) {
+            // Ignored.
+        }
+        try {
             return new File(manifestTask.multiApkManifestOutputDirectory.get().asFile, "${variantOutput.dirName}/AndroidManifest.xml")
         } catch (Throwable ignored) {
             // Ignored.
@@ -60,7 +65,10 @@ class Compatibilities {
     }
 
     static def getProcessManifestTask(project, variant) {
-        return project.tasks.findByName("process${variant.name.capitalize()}Manifest")
+        def tasks = project.tasks
+        def task = tasks.findByName("process${variant.name.capitalize()}ManifestForPackage")
+        if (task != null) return task
+        return tasks.findByName("process${variant.name.capitalize()}Manifest")
     }
 
     static def getMergeResourcesTask(project, variant) {


### PR DESCRIPTION
tinker 在 `process${variant.name.capitalize()}Manifest` 任务的产物 `build/intermediates/merged_manifests` 目录中的 `AndroidManifest.xml` 文件中写入了 `tinker_id` 等信息，而 AGP 4.1 新增了在 `process${variant.name.capitalize()}Manifest` 任务之后执行的任务 `process${variant.name.capitalize()}ManifestForPackage`，该任务的产物在 `build/intermediates/packaged_manifests` 目录中。

如果这 2 个任务命中了 gradle 缓存，执行状态都是 `FROM-CACHE`，那么最终 APK 中 manifest 文件中的 `tinker_id` 等信息是以前编译写入的旧信息。因此，对于 AGP 4.1，向 manifest 写入信息的时机应该改为 `process${variant.name.capitalize()}ManifestForPackage` 执行后，且目标文件应该改为 `build/intermediates/packaged_manifests` 目录中的 `AndroidManifest.xml` 文件。

@tomystang 