### PR TITLE
format log tag

### DIFF
--- a/tinker-android/tinker-android-loader-no-op/src/main/java/com/tencent/tinker/loader/shareutil/ShareIntentUtil.java
+++ b/tinker-android/tinker-android-loader-no-op/src/main/java/com/tencent/tinker/loader/shareutil/ShareIntentUtil.java
@@ -46,7 +46,7 @@ public class ShareIntentUtil {
     public static final  String INTENT_PATCH_INTERPRET_EXCEPTION = "intent_patch_interpret_exception";
 
 
-    private static final String TAG                              = "ShareIntentUtil";
+    private static final String TAG                              = "Tinker.ShareIntentUtil";
 
     public static void setIntentReturnCode(Intent intent, int code) {
         intent.putExtra(INTENT_RETURN_CODE, code);
@@ -195,7 +195,7 @@ public class ShareIntentUtil {
         try {
             intent.setExtrasClassLoader(cl);
         } catch (Throwable thr) {
-            thr.printStackTrace();
+            ShareTinkerLog.e(TAG, "fixIntentClassLoader exception:", thr);
         }
     }
 }

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerArkHotLoader.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/TinkerArkHotLoader.java
@@ -157,7 +157,7 @@ public class TinkerArkHotLoader {
                 try {
                     intentResult.putExtra(ShareIntentUtil.INTENT_PATCH_MISSING_DEX_PATH, apkFile.getCanonicalPath());
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    ShareTinkerLog.e(TAG, "checkComplete apkFile getCanonicalPath exception:", e);
                 }
                 ShareIntentUtil.setIntentReturnCode(intentResult,
                         ShareConstants.ERROR_LOAD_PATCH_VERSION_DEX_FILE_NOT_EXIST);

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/hotplug/handler/AMSInterceptHandler.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/hotplug/handler/AMSInterceptHandler.java
@@ -17,6 +17,7 @@ import com.tencent.tinker.loader.hotplug.IncrementComponentManager;
 import com.tencent.tinker.loader.hotplug.interceptor.ServiceBinderInterceptor.BinderInvocationHandler;
 import com.tencent.tinker.loader.shareutil.ShareIntentUtil;
 import com.tencent.tinker.loader.shareutil.ShareReflectUtil;
+import com.tencent.tinker.loader.shareutil.ShareTinkerLog;
 
 import java.lang.reflect.Method;
 
@@ -37,7 +38,7 @@ public class AMSInterceptHandler implements BinderInvocationHandler {
             try {
                 val = (int) ShareReflectUtil.findField(ActivityManager.class, "INTENT_SENDER_ACTIVITY").get(null);
             } catch (Throwable thr) {
-                thr.printStackTrace();
+                ShareTinkerLog.e(TAG, "find INTENT_SENDER_ACTIVITY field exception:", thr);
                 val = 2;
             }
         }

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareIntentUtil.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareIntentUtil.java
@@ -46,7 +46,7 @@ public class ShareIntentUtil {
     public static final  String INTENT_PATCH_INTERPRET_EXCEPTION = "intent_patch_interpret_exception";
 
 
-    private static final String TAG                              = "ShareIntentUtil";
+    private static final String TAG                              = "Tinker.ShareIntentUtil";
 
     public static void setIntentReturnCode(Intent intent, int code) {
         intent.putExtra(INTENT_RETURN_CODE, code);
@@ -195,7 +195,7 @@ public class ShareIntentUtil {
         try {
             intent.setExtrasClassLoader(cl);
         } catch (Throwable thr) {
-            thr.printStackTrace();
+            ShareTinkerLog.e(TAG, "fixIntentClassLoader exception:", thr);
         }
     }
 }

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/dexpatcher/DexPatchGenerator.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/dexpatcher/DexPatchGenerator.java
@@ -74,7 +74,7 @@ import java.util.regex.Pattern;
  * Created by tangyinsheng on 2016/6/30.
  */
 public class DexPatchGenerator {
-    private static final String TAG = "DexPatchGenerator";
+    private static final String TAG = "Tinker.DexPatchGenerator";
 
     private final Dex oldDex;
     private final Dex newDex;

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/dexpatcher/util/ChangedClassesDexClassInfoCollector.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/dexpatcher/util/ChangedClassesDexClassInfoCollector.java
@@ -43,7 +43,7 @@ import static com.tencent.tinker.build.util.DexClassesComparator.DexGroup;
  */
 
 public class ChangedClassesDexClassInfoCollector {
-    private static final String TAG = "ChangedClassesDexClassInfoCollector";
+    private static final String TAG = "Tinker.ChangedClassesDexClassInfoCollector";
 
     private static final DexPatcherLogger LOGGER = new DexPatcherLogger();
     private final Set<String> excludedClassPatterns = new HashSet<>();

--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/DexClassesComparator.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/DexClassesComparator.java
@@ -57,7 +57,7 @@ import java.util.regex.Pattern;
  * Created by tangyinsheng on 2016/4/14.
  */
 public final class DexClassesComparator {
-    private static final String TAG = "DexClassesComparator";
+    private static final String TAG = "Tinker.DexClassesComparator";
 
     public static final int COMPARE_MODE_NORMAL = 0;
     public static final int COMPARE_MODE_REFERRER_AFFECTED_CHANGE_ONLY = 1;


### PR DESCRIPTION
现在sdk中存在部分日志打印tag不规范，予以修正到均以 Tinker 开头

Now there are some log printing tags in the sdk that are not standardized, and they are corrected to start with Tinker