### PR TITLE
revert and fix parse cmdline bug

### DIFF
--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareTinkerInternals.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareTinkerInternals.java
@@ -582,9 +582,14 @@ public class ShareTinkerInternals {
         try {
             in = new BufferedInputStream(new FileInputStream("/proc/self/cmdline"));
             int len = in.read(buf);
-            while (len > 0 && (buf[len - 1] <= 0 || buf[len - 1] == 10 || buf[len - 1] == 13)) --len;
             if (len > 0) {
-                return new String(buf, StandardCharsets.US_ASCII);
+                for (int i = 0; i < len; i++) { // lots of '0' in tail , remove them
+                    if ((((int) buf[i]) & 0xFF) > 128 || buf[i] <= 0) {
+                        len = i;
+                        break;
+                    }
+                }
+                return new String(buf, 0, len);
             }
         } catch (Throwable thr) {
             ShareTinkerLog.e(TAG, "getProcessNameInternal parse cmdline exception:" + thr.getMessage());

--- a/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareTinkerInternals.java
+++ b/tinker-android/tinker-android-loader/src/main/java/com/tencent/tinker/loader/shareutil/ShareTinkerInternals.java
@@ -584,7 +584,7 @@ public class ShareTinkerInternals {
             int len = in.read(buf);
             if (len > 0) {
                 for (int i = 0; i < len; i++) { // lots of '0' in tail , remove them
-                    if ((((int) buf[i]) & 0xFF) > 128 || buf[i] <= 0) {
+                    if ((((int) buf[i]) & 0xFF) > 128 || buf[i] <= 0 || buf[i] == 10 /* lf */ || buf[i] == 13 /* cr */) {
                         len = i;
                         break;
                     }


### PR DESCRIPTION
cmdline 这块解析之前还能正常跑，新版本直接获取到一串非截断乱码。

> while (len > 0 && (buf[len - 1] <= 0 || buf[len - 1] == 10 || buf[len - 1] == 13)) --len;

问题1： 为啥要改成尾遍历，如果 X 是无效字符，`abd X edf XXXX` 中间如果出现部分有效字符，这样获取的 len 就是有问题的，得从 0 开始遍历才对。

> return new String(buf, StandardCharsets.US_ASCII);

问题2： 最后那个 len 算完，也没用进去哈。。。

