### PR TITLE
修复项目中未配置android.aaptOptions.additionalParameters时,tinkerApplyResourcePath中配置了R.txt也不生效

### DIFF
--- a/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerResourceIdTask.groovy
+++ b/tinker-build/tinker-patch-gradle-plugin/src/main/groovy/com/tencent/tinker/build/gradle/task/TinkerResourceIdTask.groovy
@@ -429,14 +429,12 @@ public class TinkerResourceIdTask extends DefaultTask {
             def processResourcesTask = Compatibilities.getProcessResourcesTask(project, variant)
             processResourcesTask.doFirst {
                 def aaptParams = project.android.aaptOptions.additionalParameters
-                if (aaptParams != null) {
-                    if (!aaptParams.contains('--stable-ids')) {
-                        addStableIdsFileToAdditionalParameters(processResourcesTask)
-                    } else {
-                        project.logger.error('** [NOTICE] ** Manually specified stable-ids file was detected, '
-                                + 'Tinker will give up injecting generated stable-ids file. Please ensure your stable-ids file '
-                                + 'keep ids of all resources in base apk.')
-                    }
+                if (aaptParams == null || !aaptParams.contains('--stable-ids')) {
+                    addStableIdsFileToAdditionalParameters(processResourcesTask)
+                } else {
+                    project.logger.error('** [NOTICE] ** Manually specified stable-ids file was detected, '
+                            + 'Tinker will give up injecting generated stable-ids file. Please ensure your stable-ids file '
+                            + 'keep ids of all resources in base apk.')
                 }
 
                 if (project.hasProperty("tinker.aapt2.public")) {


### PR DESCRIPTION
在pr未合入之前，可以暂时通过以下规避
android {
...
aaptOptions {
additionalParameters '-v'
}
...
}