### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/DiffFactory.java
+++ b/tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/DiffFactory.java
@@ -27,7 +27,7 @@ public class DiffFactory {
 
     private static void makeSurePermission(String path) throws IOException {
         try {
-            Process process = new ProcessBuilder("chmod", "777", path.split(" ")[0]).start();
+            Process process = new ProcessBuilder("chmod", "755", path.split(" ")[0]).start();
             BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
             while ((line = br.readLine()) != null) {


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/DiffFactory.java:L30`

DiffFactory.makeSurePermission() executes `chmod 777` on the user-supplied custom diff binary path. World-writable and world-executable permissions allow any local user on the build machine to overwrite the binary with malicious code, which would then be executed during patch builds. On shared/CI systems this enables local privilege escalation or supply-chain tampering. `chmod 755` is sufficient to make the binary executable for the build user.

## Solution

Replace `chmod 777` with `chmod 755` (or `700`). Also consider verifying the binary's integrity (hash check) before execution rather than blindly making it world-writable.

## Changes

- `tinker-build/tinker-patch-lib/src/main/java/com/tencent/tinker/build/util/DiffFactory.java` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._