### PR TITLE
fix: resolve #1188 — 360加固之后 补丁下载成功合成成功 之后打开一直重启

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,6 +14,12 @@ gradle版本：如:2.10
 
 是否使用热更新SDK： 如 TinkerPatch SDK 或者 Bugly SDK
 
+是否使用了APK加固工具(如 360加固/腾讯乐固/爱加密/梆梆)：是/否，若是请注明具体厂商与版本
+
+是否使用了自定义MultiDex方案或修改了tinkerId生成逻辑：是/否
+
+是否已附加LoadReporter回调日志(Tinker.with(context).getLoadReporter())及patch进程日志：是/否
+
 系统：如:Mac
 
 堆栈/日志：


### PR DESCRIPTION
## Summary

fix: resolve #1188 — 360加固之后 补丁下载成功合成成功 之后打开一直重启

## Problem

**Severity**: `Low` | **File**: `.github/ISSUE_TEMPLATE.md`

A large fraction of "patch merged but app won't start" reports stem from APK hardening, custom multi-dex loaders, or mismatched `tinkerId`. The current template appears to ask for tinker version, gradle version, SDK, and OS, but does not prompt the reporter to disclose whether they used a hardener or to attach the relevant `Tinker.with(...).getLoadReporter()` / `tinker_server` logs. Adding two checkbox-style questions makes triage instant and gives the reporter a chance to self-diagnose.

## Solution

Add fields to the template:

## Changes

- `.github/ISSUE_TEMPLATE.md` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._