### PR TITLE
fix: resolve #1120 — UpgradePatch 建议

### DIFF
--- a/tinker-android/tinker-android-lib-no-op/src/main/java/com/tencent/tinker/lib/patch/UpgradePatch.java
+++ b/tinker-android/tinker-android-lib-no-op/src/main/java/com/tencent/tinker/lib/patch/UpgradePatch.java
@@ -19,8 +19,12 @@ package com.tencent.tinker.lib.patch;
 import android.content.Context;
 
 import com.tencent.tinker.lib.service.PatchResult;
+import com.tencent.tinker.lib.tinker.Tinker;
 import com.tencent.tinker.lib.util.TinkerLog;
+import com.tencent.tinker.loader.shareutil.ShareSecurityCheck;
 import com.tencent.tinker.loader.shareutil.ShareTinkerLog;
+
+import java.io.File;
 
 
 /**
@@ -32,6 +36,30 @@ public class UpgradePatch extends AbstractPatch {
 
     @Override
     public boolean tryPatch(Context context, String tempPatchPath, boolean useEmergencyMode, PatchResult patchResult) {
+        ShareTinkerLog.e(TAG, "[-] Ignore this invocation since I'm no-op version.");
+        return false;
+    }
+
+    public boolean tryRecoverDexFiles(Tinker manager, ShareSecurityCheck checker, Context context,
+                                      String patchVersionDirectory, File patchFile) {
+        ShareTinkerLog.e(TAG, "[-] Ignore this invocation since I'm no-op version.");
+        return false;
+    }
+
+    public boolean tryRecoverLibraryFiles(Tinker manager, ShareSecurityCheck checker, Context context,
+                                          String patchVersionDirectory, File patchFile) {
+        ShareTinkerLog.e(TAG, "[-] Ignore this invocation since I'm no-op version.");
+        return false;
+    }
+
+    public boolean tryRecoverResourceFiles(Tinker manager, ShareSecurityCheck checker, Context context,
+                                           String patchVersionDirectory, File patchFile) {
+        ShareTinkerLog.e(TAG, "[-] Ignore this invocation since I'm no-op version.");
+        return false;
+    }
+
+    public boolean tryRecoverArkHotLibrary(Tinker manager, ShareSecurityCheck checker, Context context,
+                                           String patchVersionDirectory, File patchFile) {
         ShareTinkerLog.e(TAG, "[-] Ignore this invocation since I'm no-op version.");
         return false;
     }


### PR DESCRIPTION
## Summary

fix: resolve #1120 — UpgradePatch 建议

## Problem

**Severity**: `Low` | **File**: `tinker-android/tinker-android-lib-no-op/src/main/java/com/tencent/tinker/lib/patch/UpgradePatch.java`

The no-op variant of `tinker-android-lib` exposes the same `UpgradePatch` API surface as the real library. To keep the two artifacts swappable at build time, the same `protected` -> `public` visibility promotion must be applied here. If only the real lib is updated, consumers who depend on `tinker-android-lib-no-op` (typically for release/no-op flavors) would see a different API and lose access to the now-public helpers, which would defeat the purpose of the change.

## Solution

In `tinker-android/tinker-android-lib-no-op/src/main/java/com/tencent/tinker/lib/patch/UpgradePatch.java`, mirror the modifications made in the real lib: change `protected` to `public` on the same set of recover/merge helper methods (`tryRecoverDexFiles`, `tryRecoverLibraryFiles`, `tryRecoverResourceFiles`, and any other `protected` helpers present). Keep the method bodies as-is (they are no-ops in this module). Build the module with `./gradlew :tinker-android:tinker-android-lib-no-op:assemble` to verify the change compiles cleanly.

## Changes

- `tinker-android/tinker-android-lib-no-op/src/main/java/com/tencent/tinker/lib/patch/UpgradePatch.java` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._