### PR TITLE
fix: resolve #1114 — 1.9.13在android 26（含）以上无法合成补丁

### DIFF
--- a/tinker-android/tinker-android-lib/src/main/AndroidManifest.xml
+++ b/tinker-android/tinker-android-lib/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tencent.tinker.lib">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application>
         <service
             android:name=".service.TinkerPatchForeService"
@@ -18,7 +20,6 @@
         <service
             android:name=".service.TinkerPatchService"
             android:exported="false"
-            android:permission="android.permission.BIND_JOB_SERVICE"
             android:process=":patch" />
         <service
             android:name=".service.TinkerPatchService$InnerService"

--- a/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/service/DefaultTinkerResultService.java
+++ b/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/service/DefaultTinkerResultService.java
@@ -17,6 +17,12 @@
 package com.tencent.tinker.lib.service;
 
 
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
 import com.tencent.tinker.lib.tinker.Tinker;
 import com.tencent.tinker.lib.tinker.TinkerLoadResult;
 import com.tencent.tinker.loader.shareutil.ShareTinkerLog;
@@ -102,5 +108,28 @@ public class DefaultTinkerResultService extends AbstractResultService {
         return true;
     }
 
+    public static class DefaultNotificationProvider {
+        public static final int NOTIFICATION_ID = 0x1;
+        private static final String CHANNEL_ID = "tinker_patch";
+        private static final String CHANNEL_NAME = "Tinker Patch";
+
+        public static Notification createNotification(Context context) {
+            final Notification.Builder builder;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                final NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                if (manager != null) {
+                    manager.createNotificationChannel(new NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW));
+                }
+                builder = new Notification.Builder(context, CHANNEL_ID);
+            } else {
+                builder = new Notification.Builder(context);
+            }
+            return builder.setContentTitle("Tinker")
+                .setContentText("Applying patch")
+                .setOngoing(true)
+                .setSmallIcon(context.getApplicationInfo().icon)
+                .build();
+        }
+    }
 
 }

--- a/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/service/TinkerPatchService.java
+++ b/tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/service/TinkerPatchService.java
@@ -21,6 +21,8 @@ import static com.tencent.tinker.lib.util.TinkerServiceInternals.getTinkerPatchS
 import android.app.ActivityManager;
 import android.app.IntentService;
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -53,6 +55,15 @@ public class TinkerPatchService extends IntentService {
     private static AbstractPatch upgradePatchProcessor = null;
     private static int notificationId = ShareConstants.TINKER_PATCH_SERVICE_NOTIFICATION;
     private static Class<? extends AbstractResultService> resultServiceClass = null;
+    private static ForegroundNotificationFactory foregroundNotificationFactory = null;
+
+    public interface ForegroundNotificationFactory {
+        Notification create(Service service);
+    }
+
+    public static void setForegroundNotificationFactory(ForegroundNotificationFactory factory) {
+        foregroundNotificationFactory = factory;
+    }
 
     public TinkerPatchService() {
         super("TinkerPatchService");
@@ -70,7 +81,11 @@ public class TinkerPatchService extends IntentService {
         intent.putExtra(PATCH_USE_EMERGENCY_MODE, useEmergencyMode);
         intent.putExtra(RESULT_CLASS_EXTRA, resultServiceClass.getName());
         try {
-            context.startService(intent);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent);
+            } else {
+                context.startService(intent);
+            }
         } catch (Throwable thr) {
             ShareTinkerLog.e(TAG, "run patch service fail, exception:" + thr);
         }
@@ -106,6 +121,47 @@ public class TinkerPatchService extends IntentService {
             throw new TinkerRuntimeException("getPatchResultExtra, but intent is null");
         }
         return ShareIntentUtil.getStringExtra(intent, RESULT_CLASS_EXTRA);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        ensureForeground();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        ensureForeground();
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    private void ensureForeground() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+        try {
+            startForeground(notificationId, createForegroundNotification());
+        } catch (Throwable thr) {
+            ShareTinkerLog.e(TAG, "startForeground fail, exception:" + thr);
+        }
+    }
+
+    private Notification createForegroundNotification() {
+        if (foregroundNotificationFactory != null) {
+            return foregroundNotificationFactory.create(this);
+        }
+        final String channelId = "tinker_patch_service";
+        final NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null && nm.getNotificationChannel(channelId) == null) {
+            final NotificationChannel channel = new NotificationChannel(channelId, "TinkerPatchService", NotificationManager.IMPORTANCE_LOW);
+            nm.createNotificationChannel(channel);
+        }
+        return new Notification.Builder(this, channelId)
+                .setSmallIcon(getApplicationInfo().icon)
+                .setContentTitle("Tinker")
+                .setContentText("Applying patch")
+                .setOngoing(true)
+                .build();
     }
 
     @Override


### PR DESCRIPTION
## Summary

fix: resolve #1114 — 1.9.13在android 26（含）以上无法合成补丁

## Problem

**Severity**: `Critical` | **File**: `tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/service/TinkerPatchService.java`

On Android 26+, Tinker 1.9.13 dispatches patch work through `JobIntentService`, which sits on top of `JobScheduler`. `JobScheduler` does not guarantee timely execution of jobs scheduled while the app is in background, and several OEM ROMs (MIUI, EMUI, ColorOS, etc.) refuse to dispatch jobs at all unless the app has "auto-start" permission. This matches the user's observation that the patch silently never starts unless auto-start is granted. The fix is to keep using a regular `IntentService`/`Service` and promote it to a foreground service via `startForegroundService` + `startForeground` on API 26+, so the OS allows it to run regardless of background state. The notification used by `startForeground` should be customizable by the host app so it does not surprise end users.

## Solution



## Changes

- `tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/service/TinkerPatchService.java` (modified)
- `tinker-android/tinker-android-lib/src/main/AndroidManifest.xml` (modified)
- `tinker-android/tinker-android-lib/src/main/java/com/tencent/tinker/lib/service/DefaultTinkerResultService.java` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._