### PR TITLE
fix: resolve #1074 — Gradle 5.1.1依赖传递丢失tinker-android-loader

### DIFF
--- a/tinker-android/tinker-android-lib/build.gradle
+++ b/tinker-android/tinker-android-lib/build.gradle
@@ -50,6 +50,18 @@ task buildTinkerSdk(type: Copy, dependsOn: [build]) {
 
 apply from: rootProject.file('gradle/PublishArtifact.gradle')
 
+afterEvaluate {
+    if (tasks.findByName('uploadArchives')) {
+        uploadArchives.repositories.mavenDeployer.pom.whenConfigured { pom ->
+            pom.dependencies.findAll {
+                it.artifactId == 'tinker-android-loader' || it.artifactId == 'tinker-commons'
+            }.each { dep ->
+                dep.scope = 'compile'
+            }
+        }
+    }
+}
+
 
 
 


### PR DESCRIPTION
## Summary

fix: resolve #1074 — Gradle 5.1.1依赖传递丢失tinker-android-loader

## Problem

**Severity**: `High` | **File**: `tinker-android/tinker-android-lib/build.gradle`

The root cause is that `tinker-android-loader` is currently declared in `tinker-android-lib/build.gradle` using a configuration (likely `provided` or `compileOnly`) that gets serialized into the published POM with `<scope>provided</scope>`. Gradle 4.x leniently included `provided` dependencies as transitive in some resolution paths, but Gradle 5.x strictly excludes them, which is why users on AS 3.4 / Gradle 5.1.1 see the dependency vanish from the resolved graph. Meanwhile `tinker-commons` is declared as `compile`/`api`, so it still appears.

## Solution



## Changes

- `tinker-android/tinker-android-lib/build.gradle` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._